### PR TITLE
I just bought a 2.53i ratgdo controller which sends a motion status

### DIFF
--- a/ratgdo.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/ratgdo.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -75,7 +75,14 @@ class Plugin(indigo.PluginBase):
                     continue
 
                 ratgdo_status = topic_parts[3]
-                device.updateStateOnServer(key=ratgdo_status, value=payload)
+                
+                # if a newer version of ratgdo sends statuses we don't know
+                # about, let's just skip them until we can add them to
+                # Devices.xml as known states.
+                if ratgdo_status in device.states.keys():
+                    device.updateStateOnServer(key=ratgdo_status, value=payload)
+                else:
+                    self.logger.debug(f"processMessage: status type {ratgdo_status} not a known state, skipping updating on server")
 
                 if ratgdo_status == "door":
                     if payload == "closed":


### PR DESCRIPTION
msg.  Due to this I was seeing this in the indigo logs:

   Error                           device "GarageController" state key motion not defined (ignoring update request)

So this small change will allow us to skip over new statuses from ratgdo that we don't know about.  As they come out, they can be added to Devices.xml at some point in the future.